### PR TITLE
Fix Shadowrocket MITM coverage for rewritten Apple TV hosts

### DIFF
--- a/shadowrocket/apple-video-subtitles.module
+++ b/shadowrocket/apple-video-subtitles.module
@@ -26,4 +26,4 @@ AppleTV.Movie.Interstellar.zh-Hans.French.response = type=http-response,engine=w
 
 [MITM]
 h2 = true
-hostname = %APPEND% hls-amt.itunes.apple.com, uts-api.itunes.apple.com, play-cdn.itunes.apple.com, play-edge-cdn.itunes.apple.com, vod-ap-aoc.tv.apple.com, vod-fa-aoc.tv.apple.com, vod-ak-aoc.tv.apple.com, vod-ap-amt.tv.apple.com, vod-fa-amt.tv.apple.com, vod-ak-amt.tv.apple.com
+hostname = %APPEND% hls-amt.itunes.apple.com, uts-api.itunes.apple.com, play-cdn.itunes.apple.com, play.itunes.apple.com, play-edge-cdn.itunes.apple.com, play-edge.itunes.apple.com, vod-ap-aoc.tv.apple.com, vod-fa-aoc.tv.apple.com, vod-ak-aoc.tv.apple.com, vod-ap-amt.tv.apple.com, vod-fa-amt.tv.apple.com, vod-ak-amt.tv.apple.com


### PR DESCRIPTION
历史成品更新记录。实际可用内容以当前模块、字幕成品及 Release 为准。