### PR TITLE
Disable Shadowrocket HTTP2 MITM override for Apple TV playback

### DIFF
--- a/shadowrocket/apple-video-subtitles.module
+++ b/shadowrocket/apple-video-subtitles.module
@@ -25,5 +25,4 @@ AppleTV.Movie.GoneGirl.zh-Hans.Added.VTT.response = type=http-response,engine=we
 AppleTV.Movie.Interstellar.zh-Hans.French.response = type=http-response,engine=webview,pattern=^https:\/\/vod-(?:ap|fa|ak)-amt\.tv\.apple\.com\/itunes-assets\/(?:[^\/]+\/)+P1220541004_A960891136_fr-FR_subtitles_V2-\d+\.webvtt(?:\?.*)?$,requires-body=1,max-size=2097152,timeout=30,script-path=https://raw.githubusercontent.com/rexchen1803/apple-video-subtitles/main/payloads/movies/2014-interstellar/serve_interstellar_fr_as_zh_hans.js
 
 [MITM]
-h2 = true
 hostname = %APPEND% hls-amt.itunes.apple.com, uts-api.itunes.apple.com, play-cdn.itunes.apple.com, play.itunes.apple.com, play-edge-cdn.itunes.apple.com, play-edge.itunes.apple.com, vod-ap-aoc.tv.apple.com, vod-fa-aoc.tv.apple.com, vod-ak-aoc.tv.apple.com, vod-ap-amt.tv.apple.com, vod-fa-amt.tv.apple.com, vod-ak-amt.tv.apple.com


### PR DESCRIPTION
历史成品更新记录。实际可用内容以当前模块、字幕成品及 Release 为准。