### PR TITLE
Use stable main URLs for module updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,9 +22,9 @@
 
 | 工具 | 添加位置 | 下载地址 |
 | --- | --- | --- |
-| Surge | 模块 | [点击下载](https://raw.githubusercontent.com/rexchen1803/apple-video-subtitles/v260822A/surge/apple-video-subtitles.sgmodule) |
-| Stash | 覆写 | [点击下载](https://raw.githubusercontent.com/rexchen1803/apple-video-subtitles/v260822A/stash/apple-video-subtitles.stoverride) |
-| Shadowrocket | 模块 | [点击下载](https://raw.githubusercontent.com/rexchen1803/apple-video-subtitles/v260822A/shadowrocket/apple-video-subtitles.module) |
+| Surge | 模块 | [点击下载](https://raw.githubusercontent.com/rexchen1803/apple-video-subtitles/main/surge/apple-video-subtitles.sgmodule) |
+| Stash | 覆写 | [点击下载](https://raw.githubusercontent.com/rexchen1803/apple-video-subtitles/main/stash/apple-video-subtitles.stoverride) |
+| Shadowrocket | 模块 | [点击下载](https://raw.githubusercontent.com/rexchen1803/apple-video-subtitles/main/shadowrocket/apple-video-subtitles.module) |
 
 ---
 


### PR DESCRIPTION
将 README 中的三个模块下载地址改为固定的 main 分支地址。用户替换一次后，今后刷新同一地址即可获得最新模块；v260822A 版本地址继续保留用于历史版本。